### PR TITLE
Support for IdentityServer4 >= 3.0.0 targeting netcoreapp3.1

### DIFF
--- a/IdentityServer4.Contrib.Saml2BearerGrant.sln
+++ b/IdentityServer4.Contrib.Saml2BearerGrant.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30621.155
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentityServer4.Contrib.Saml2BearerGrant", "src\IdentityServer4.Contrib.Saml2BearerGrant\IdentityServer4.Contrib.Saml2BearerGrant.csproj", "{A18C8DBE-DE12-48E5-A8BA-B5D16C7FDE7A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityServer4.Contrib.Saml2BearerGrant.Tests", "test\IdentityServer4.Contrib.Saml2BearerGrant.Tests\IdentityServer4.Contrib.Saml2BearerGrant.Tests.csproj", "{B17393B8-798D-44A4-BA08-1F3DCD4892B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentityServer4.Contrib.Saml2BearerGrant.Tests", "test\IdentityServer4.Contrib.Saml2BearerGrant.Tests\IdentityServer4.Contrib.Saml2BearerGrant.Tests.csproj", "{B17393B8-798D-44A4-BA08-1F3DCD4892B4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/IdentityServer4.Contrib.Saml2BearerGrant/BaseSamlBearerGrantValidator.cs
+++ b/src/IdentityServer4.Contrib.Saml2BearerGrant/BaseSamlBearerGrantValidator.cs
@@ -13,6 +13,7 @@ using Microsoft.IdentityModel.Tokens.Saml2;
 using Microsoft.IdentityModel.Xml;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -79,7 +80,9 @@ namespace IdentityServer4.Contrib.Saml2BearerGrant
                 return;
             }
 
-            IEnumerable<SecurityKey> signingKeys = await _keys.GetValidationKeysAsync();
+            IEnumerable<SecurityKeyInfo> signingKeysInfos = await _keys.GetValidationKeysAsync();
+            List<SecurityKey> signingKeys = signingKeysInfos.Select(e => e.Key).ToList();
+
             string idSrvIssuerUri = _httpContextAccessor.HttpContext.GetIdentityServerIssuerUri();
             var lifetimeValidator = new LifetimeValidator(_systemClock);
 

--- a/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
+++ b/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Peter Doering</Authors>
     <PackageTags>saml2;identityserver</PackageTags>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <Description>Extension grant types for IdentityServer4 implementing a subset of RFC 7522 (https://tools.ietf.org/html/rfc7522).
 
 Adds support for SAML 2.0 and SAML 1.1 assertions as grant for token requests.

--- a/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
+++ b/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
@@ -19,7 +19,7 @@ This extension was built for legacy applications using SAML or WS-Federation aut
 
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="3.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="5.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
+++ b/src/IdentityServer4.Contrib.Saml2BearerGrant/IdentityServer4.Contrib.Saml2BearerGrant.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Peter Doering</Authors>
     <PackageTags>saml2;identityserver</PackageTags>
@@ -18,7 +18,7 @@ This extension was built for legacy applications using SAML or WS-Federation aut
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.3.0" />
+    <PackageReference Include="IdentityServer4" Version="3.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="5.3.0" />
   </ItemGroup>
 

--- a/test/IdentityServer4.Contrib.Saml2BearerGrant.Tests/Helpers/SamlBearerGrantValidatorFactory.cs
+++ b/test/IdentityServer4.Contrib.Saml2BearerGrant.Tests/Helpers/SamlBearerGrantValidatorFactory.cs
@@ -1,5 +1,6 @@
 ﻿using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
+using IdentityServer4.Models;
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -45,7 +46,8 @@ namespace IdentityServer4.Contrib.Saml2BearerGrant.Tests.Helpers
                 .Returns(Task.FromResult(SigningCredentials));
 
             keys.Setup(x => x.GetValidationKeysAsync())
-                .Returns(Task.FromResult(new[] { SigningCredentials.Key }.AsEnumerable()));
+                .Returns(Task.FromResult(
+                    new[] { new SecurityKeyInfo { Key = SigningCredentials.Key } }.AsEnumerable()));
 
             var systemClock = new SystemClock();
 

--- a/test/IdentityServer4.Contrib.Saml2BearerGrant.Tests/IdentityServer4.Contrib.Saml2BearerGrant.Tests.csproj
+++ b/test/IdentityServer4.Contrib.Saml2BearerGrant.Tests/IdentityServer4.Contrib.Saml2BearerGrant.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated the library to support the recent version of IdentityServer4 thats targets netcoreapp3.1.